### PR TITLE
Add Show/Hide menu for some CM3D2 model bones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-
+.vscode
 *.zip

--- a/CM3D2 Converter/__init__.py
+++ b/CM3D2 Converter/__init__.py
@@ -58,6 +58,8 @@ if "bpy" in locals():
     imp.reload(misc_VIEW3D_PT_tools_mesh_shapekey)
     imp.reload(misc_DOPESHEET_MT_editor_menus)
 
+    imp.reload(misc_VIEW3D_MT_pose_showhide)
+
 else:
     from . import compat
     from . import common
@@ -98,6 +100,8 @@ else:
     from . import misc_VIEW3D_PT_tools_weightpaint
     from . import misc_VIEW3D_PT_tools_mesh_shapekey
     from . import misc_DOPESHEET_MT_editor_menus
+
+    from . import misc_VIEW3D_MT_pose_showhide
 
 import bpy, os.path, bpy.utils.previews
 
@@ -342,6 +346,7 @@ def register():
     bpy.types.OBJECT_PT_transform.append(misc_OBJECT_PT_transform.menu_func)
     bpy.types.TEXT_HT_header.append(misc_TEXT_HT_header.menu_func)
     bpy.types.VIEW3D_MT_pose_apply.append(misc_VIEW3D_MT_pose_apply.menu_func)
+    bpy.types.VIEW3D_MT_pose_showhide.append(misc_VIEW3D_MT_pose_showhide.menu_func)
 
     setattr(bpy.types.Object, 'cm3d2_bone_morph',  bpy.props.PointerProperty(type=misc_DATA_PT_context_arm.CNV_PG_cm3d2_bone_morph ))
     setattr(bpy.types.Object, 'cm3d2_wide_slider', bpy.props.PointerProperty(type=misc_DATA_PT_context_arm.CNV_PG_cm3d2_wide_slider))

--- a/CM3D2 Converter/misc_VIEW3D_MT_pose_showhide.py
+++ b/CM3D2 Converter/misc_VIEW3D_MT_pose_showhide.py
@@ -1,0 +1,41 @@
+import bpy
+from . import common
+from . import compat
+
+def menu_func(self, context):
+    icon_id = common.kiss_icon()
+    self.layout.separator()
+    self.layout.operator('script.hide_cm3d2_bones', icon_value=icon_id)
+    self.layout.operator('script.show_cm3d2_bones', icon_value=icon_id)
+
+@compat.BlRegister()
+class CNV_OT_hide_cm3d2_bones(bpy.types.Operator):
+    bl_idname = 'script.hide_cm3d2_bones'
+    bl_label = "Hide SCL, IK, and momo bones"
+    bl_description = "Hides bones in the current pose containing 'SCL', 'IK', and 'momo' in their names"
+    bl_options = {'REGISTER'}
+
+    def execute(self, context):
+        for obj in context.selected_objects:
+            pose = obj.pose
+            for pose_bone in pose.bones:
+                bone = pose_bone.bone
+                if '_IK_' in bone.name or '_SCL_' in bone.name or 'momo' in bone.name:
+                    bone.hide = True
+        return {'FINISHED'}
+
+@compat.BlRegister()
+class CNV_OT_show_cm3d2_bones(bpy.types.Operator):
+    bl_idname = 'script.show_cm3d2_bones'
+    bl_label = "Show SCL, IK, and momo bones"
+    bl_description = "Shows bones in the current pose containing 'SCL', 'IK', and 'momo' in their names"
+    bl_options = {'REGISTER'}
+
+    def execute(self, context):
+        for obj in context.selected_objects:
+            pose = obj.pose
+            for pose_bone in pose.bones:
+                bone = pose_bone.bone
+                if '_IK_' in bone.name or '_SCL_' in bone.name or 'momo' in bone.name:
+                    bone.hide = False
+        return {'FINISHED'}


### PR DESCRIPTION
Adds menu items to the `Pose > Show/Hide` menu to quickly hide or show bones in the current pose containing `"IK"`, `"SCL"`, or `momo`.

Fixes #6