### PR TITLE
Fix materials not being imported if they have a duplicate name

### DIFF
--- a/CM3D2 Converter/cm3d2_data.py
+++ b/CM3D2 Converter/cm3d2_data.py
@@ -476,6 +476,11 @@ class Material():
     def name(self):
         return self.name2 or self.name1
 
+    @name.setter
+    def name(self, new_name: str):
+        self.name1 = new_name
+        self.name2 = new_name
+    
     def read(self, reader, read_header=True):
         if read_header:
             header = common.read_str(reader)

--- a/CM3D2 Converter/model_import.py
+++ b/CM3D2 Converter/model_import.py
@@ -262,17 +262,14 @@ class CNV_OT_import_cm3d2_model(bpy.types.Operator, bpy_extras.io_utils.ImportHe
                     print(f_("mate count: {num} of {count} @ 0x{pos:02X}", num=i, count=material_count, pos=reader.tell()))
                     data = cm3d2_data.MaterialHandler.read(reader, read_header=False, version=model_ver)
                     
-                    if data.name.lower() in material_names:
-                        print(f"duplicate material name found! {data.name.lower()}")
-                        material_names[data.name.lower()] += 1
+                    data.name1 = data.name.lower()
+                    if data.name1 in material_names:
+                        print(f"duplicate material name found! {data.name1}")
+                        material_names[data.name1] += 1
                         new_name = data.name.lower() + "_" + str(material_names.get(data.name.lower()))
-                        material_names[new_name] = 1
                         data.name1 = new_name
-                    else:
-                        data.name1 = data.name.lower()
-                        material_names[data.name1] = 1
-
-                    #data.name1 = data.name.lower()
+                    
+                    material_names[data.name1] = 1
                     material_data.append(data)
                     
                     # name1 = common.read_str(reader)

--- a/CM3D2 Converter/model_import.py
+++ b/CM3D2 Converter/model_import.py
@@ -266,6 +266,7 @@ class CNV_OT_import_cm3d2_model(bpy.types.Operator, bpy_extras.io_utils.ImportHe
                         print(f"duplicate material name found! {data.name.lower()}")
                         material_names[data.name.lower()] += 1
                         new_name = data.name.lower() + "_" + str(material_names.get(data.name.lower()))
+                        material_names[new_name] = 1
                         data.name1 = new_name
                     else:
                         data.name1 = data.name.lower()
@@ -689,12 +690,11 @@ class CNV_OT_import_cm3d2_model(bpy.types.Operator, bpy_extras.io_utils.ImportHe
                 print(f_("material count: {num} of {count}", num=index, count=material_count))
 
                 print("    name: " + data.name)
-                if data.name not in data_names_map:
-                    data_names_map[data.name] = 1
-                else:
+                if data.name in data_names_map:
                     data_names_map[data.name] += 1
                     print(f"duplicate material name found! {data.name}")
                     data.name = data.name + "_" + str(data_names_map.get(data.name))
+                data_names_map[data.name] = 1
 
                 # may not be needed
                 if prefs.mate_unread_same_value and data.name in mates_set:


### PR DESCRIPTION
Materials with duplicate names will be imported with "_<number>" appending their name.

Example: A model with material names {"mate", "mate"} will be imported as "mate" and "mate_2".