### PR TITLE
Fix pose apply keep original not keeping original base pose.

### DIFF
--- a/CM3D2 Converter/__init__.py
+++ b/CM3D2 Converter/__init__.py
@@ -4,7 +4,7 @@
 bl_info = {
     "name": "CM3D2 Converter",
     "author": "@saidenka_cm3d2, @trzrz, @luvoid",
-    "version": ("luv", 2023, 9, "pre-19a"),
+    "version": ("luv", 2023, 12, "pre-22"),
     "blender": (3, 3, 0),
     "location": "ファイル > インポート/エクスポート > CM3D2 Model (.model)",
     "description": "カスタムメイド3D2/カスタムオーダーメイド3D2専用ファイルのインポート/エクスポートを行います",

--- a/CM3D2 Converter/common.py
+++ b/CM3D2 Converter/common.py
@@ -1373,6 +1373,14 @@ def get_target_and_source_ob(context: bpy.context, copyTarget=False, copySource=
     target_original_ob: bpy.types.Object = None
     source_original_ob: bpy.types.Object = None
 
+    if not (copyTarget or copySource):
+        target_ob = context.active_object
+        for ob in context.selected_objects:
+            if ob != target_ob:
+                source_ob = ob
+                break
+        return (target_ob, source_ob)
+
     selected_objects = list(context.selected_objects)
     
     target_original_ob = context.active_object

--- a/CM3D2 Converter/misc_VIEW3D_MT_pose_apply.py
+++ b/CM3D2 Converter/misc_VIEW3D_MT_pose_apply.py
@@ -292,7 +292,11 @@ class CNV_OT_apply_prime_field(bpy.types.Operator):
                     drivers.remove(driver)
             #context.scene.frame_set(1)
             bpy.ops.pose.user_transforms_clear()
+
+            compat.set_active(context, temp_ob)
             bpy.ops.poselib.apply_pose(pose_index=1)
+            bpy.ops.pose.armature_apply()
+            compat.set_active(context, ob)
         else:
             compat.set_active(context, temp_ob)
             bpy.ops.object.mode_set(mode='POSE')


### PR DESCRIPTION
When running apply prime on an already primed armature, the "Keep original" option does not actually keep the original pose. Hence when clicking the "Original" button on the cm3d2 armature panel, it does not show the original pose.

To reproduce:
1. in an empty blender scene, add a T-pose body
2. alter the pose by rotationg / repositioning some bones in pose mode
3. Pose > Apply > Apply Prime Field with "Keep original" checked.
4. In the cm3d2 armature panel, click "original" to bring up the base pose.

Expected:
Armature returns to the motorcycle pose (the base pose for the T-pose body)

Actual result:
Armature returns to T-pose and the motorcycle pose is lost.

There was some somewhat harmless errors during poll() functions of the apply operators, which happens because it modifies blender state when it should not (changing object selections) via the get_target_and_source_ob function. I've added a special case to return immediately without modifying editor state if it isnt really being asked to copy anything.